### PR TITLE
refactor: prioritize bsa over codefund

### DIFF
--- a/main.go
+++ b/main.go
@@ -43,15 +43,6 @@ func ServeAd(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if res == nil {
-		cf, err := fetchCodefund(r, "a4ace977-6531-4708-a4d9-413c8910ac2c")
-		if err != nil {
-			log.Warn("failed to fetch ad from Codefund ", err)
-		} else if cf != nil {
-			res = []interface{}{*cf}
-		}
-	}
-
-	if res == nil {
 		var bsa *BsaAd
 		var err error
 		if country == "united states" {
@@ -65,6 +56,16 @@ func ServeAd(w http.ResponseWriter, r *http.Request) {
 			res = []interface{}{*bsa}
 		}
 	}
+
+	if res == nil {
+		cf, err := fetchCodefund(r, "a4ace977-6531-4708-a4d9-413c8910ac2c")
+		if err != nil {
+			log.Warn("failed to fetch ad from Codefund ", err)
+		} else if cf != nil {
+			res = []interface{}{*cf}
+		}
+	}
+
 	if res == nil {
 		// Look for a fallback campaign ad based on probability
 		prob := rand.Float32()

--- a/serve_ad_test.go
+++ b/serve_ad_test.go
@@ -187,6 +187,7 @@ func TestCodefundAvailable(t *testing.T) {
 	}
 
 	fetchCampaigns = campaignNotAvailable
+	fetchBsa = bsaNotAvailable
 	fetchCodefund = func(r *http.Request, propertyId string) (*CodefundAd, error) {
 		return &exp[0], nil
 	}
@@ -206,7 +207,7 @@ func TestCodefundAvailable(t *testing.T) {
 	assert.Equal(t, exp, actual, "wrong body")
 }
 
-func TestCodefundNotAvailable(t *testing.T) {
+func TestCodefundFail(t *testing.T) {
 	exp := []BsaAd{
 		{
 			Ad:           ad,
@@ -215,7 +216,11 @@ func TestCodefundNotAvailable(t *testing.T) {
 		},
 	}
 
-	fetchCodefund = codefundNotAvailable
+	fetchCampaigns = campaignNotAvailable
+	fetchBsa = bsaNotAvailable
+	fetchCodefund = func(r *http.Request, propertyId string) (*CodefundAd, error) {
+		return nil, errors.New("error")
+	}
 	fetchBsa = func(r *http.Request, propertyId string) (*BsaAd, error) {
 		return &exp[0], nil
 	}
@@ -235,7 +240,7 @@ func TestCodefundNotAvailable(t *testing.T) {
 	assert.Equal(t, exp, actual, "wrong body")
 }
 
-func TestCodefundFail(t *testing.T) {
+func TestBsaAvailable(t *testing.T) {
 	exp := []BsaAd{
 		{
 			Ad:           ad,
@@ -244,10 +249,7 @@ func TestCodefundFail(t *testing.T) {
 		},
 	}
 
-	fetchCampaigns = campaignNotAvailable
-	fetchCodefund = func(r *http.Request, propertyId string) (*CodefundAd, error) {
-		return nil, errors.New("error")
-	}
+	fetchCodefund = codefundNotAvailable
 	fetchBsa = func(r *http.Request, propertyId string) (*BsaAd, error) {
 		return &exp[0], nil
 	}


### PR DESCRIPTION
Due to lack of inventory, it's better to serve BSA with high priority