### PR TITLE
refactor: read cookies instead of header

### DIFF
--- a/main.go
+++ b/main.go
@@ -48,7 +48,12 @@ func ServeAd(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	segment, _ := findSegment(r.Context(), r.Header.Get("User-Id"))
+	var userId string
+	cookie, _ := r.Cookie("da2")
+	if cookie != nil {
+		userId = cookie.Value
+	}
+	segment, _ := findSegment(r.Context(), userId)
 	if res == nil {
 		var bsa *BsaAd
 		var err error

--- a/main.go
+++ b/main.go
@@ -171,6 +171,12 @@ func (h *App) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case "a":
 		h.AdsHandler.ServeHTTP(w, r)
 		return
+	case "v1":
+		head, r.URL.Path = shiftPath(r.URL.Path)
+		if head == "a" {
+			h.AdsHandler.ServeHTTP(w, r)
+		}
+		return
 	}
 
 	http.Error(w, "Not Found", http.StatusNotFound)


### PR DESCRIPTION
This change turns the monetization service into a standalone service that does not require the gateway to parse cookies.
This can improve the performance of the service