### PR TITLE
fix: only add `https:` prefix if it is missing

### DIFF
--- a/bsa.go
+++ b/bsa.go
@@ -51,7 +51,10 @@ var fetchBsa = func(r *http.Request, propertyId string) (*BsaAd, error) {
 			}
 			retAd.Image, _ = ad["smallImage"].(string)
 			retAd.Link, _ = ad["statlink"].(string)
-			retAd.Link = fmt.Sprintf("https:%s", retAd.Link)
+			// Prepend https: to the link if it's missing
+			if !strings.HasPrefix(retAd.Link, "https:") {
+				retAd.Link = fmt.Sprintf("https:%s", retAd.Link)
+			}
 			retAd.ReferralLink, _ = ad["ad_via_link"].(string)
 			retAd.Source = "Carbon"
 			retAd.Company = retAd.Source


### PR DESCRIPTION
More and more reports of ads with `https:https://` prefixes, so only prepend it if it is missing.